### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/add_urls.py
+++ b/add_urls.py
@@ -17,7 +17,7 @@ for m in Ministr.objects.filter(wikipedia = ''): #all():
     print m.jmeno
     webbrowser.open(m.wikipedia)
     if m.wikipedia is None or m.wikipedia == '':
-        u = 'http://cs.wikipedia.org/wiki/%s' % (urllib.quote(m.jmeno.replace(' ', '_').encode('utf-8')))
+        u = 'http://cs.wikipedia.org/wiki/{0!s}'.format((urllib.quote(m.jmeno.replace(' ', '_').encode('utf-8'))))
         webbrowser.open(u)
         s = raw_input('Wikipedia: ')
         if s == '':
@@ -29,7 +29,7 @@ for m in Ministr.objects.filter(wikipedia = ''): #all():
         if s != '':
             m.url = s
     if m.strana is None:
-        s = raw_input('Strana (%s): ' % ' '.join(['%d: %s' % (strana.id, strana.jmeno.encode('utf-8')) for strana in Strana.objects.all()]))
+        s = raw_input('Strana ({0!s}): '.format(' '.join(['{0:d}: {1!s}'.format(strana.id, strana.jmeno.encode('utf-8')) for strana in Strana.objects.all()])))
         if s != '':
             m.strana = Strana.objects.get(pk = int(s))
     m.save()

--- a/dluhy/models.py
+++ b/dluhy/models.py
@@ -18,7 +18,7 @@ class Strana(models.Model):
         if url is None and url != '':
             return self.__unicode__()
         else:
-            return mark_safe('<a href="%s">%s</a>' % (url, self.__unicode__()))
+            return mark_safe('<a href="{0!s}">{1!s}</a>'.format(url, self.__unicode__()))
 
     def __unicode__(self):
         return self.jmeno
@@ -35,7 +35,7 @@ class Ministr(models.Model):
         return ('ministr', (), {'slug': self.slug})
 
     def get_link(self):
-        return mark_safe('<a href="%s">%s</a>' % (self.get_absolute_url(), self.__unicode__()))
+        return mark_safe('<a href="{0!s}">{1!s}</a>'.format(self.get_absolute_url(), self.__unicode__()))
 
     def __unicode__(self):
         return self.jmeno
@@ -47,7 +47,7 @@ class Rozpocet(models.Model):
     bilance = models.IntegerField(blank=True)
 
     def __unicode__(self):
-        return '%d (%d)' % (self.rok, self.bilance)
+        return '{0:d} ({1:d})'.format(self.rok, self.bilance)
 
     def save(self, *args, **kwargs):
         self.bilance = self.prijmy - self.vydaje
@@ -58,7 +58,7 @@ class Vlada(models.Model):
     rozpocet = models.ForeignKey(Rozpocet)
 
     def __unicode__(self):
-        return '%s (%d)' % (self.ministr.jmeno, self.rozpocet.rok)
+        return '{0!s} ({1:d})'.format(self.ministr.jmeno, self.rozpocet.rok)
 
     class Meta:
         unique_together = (('ministr', 'rozpocet'),)

--- a/settings.py
+++ b/settings.py
@@ -53,9 +53,9 @@ USE_L10N = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
-MEDIA_ROOT = '%s/media/' % WEB_ROOT
+MEDIA_ROOT = '{0!s}/media/'.format(WEB_ROOT)
 
-HTML_ROOT= '%s/html/' % WEB_ROOT
+HTML_ROOT= '{0!s}/html/'.format(WEB_ROOT)
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.

--- a/urls.py
+++ b/urls.py
@@ -25,9 +25,9 @@ class PagesSitemap(Sitemap):
     changefreq = 'weekly'
     def items(self):
         return [
-            ('/', '%s/index.html' % settings.HTML_ROOT, 1),
-            ('/ministri/', '%s/top.html' % settings.HTML_ROOT, 1),
-            ('/info/', '%s/info.html' % settings.HTML_ROOT, 0.5),
+            ('/', '{0!s}/index.html'.format(settings.HTML_ROOT), 1),
+            ('/ministri/', '{0!s}/top.html'.format(settings.HTML_ROOT), 1),
+            ('/info/', '{0!s}/info.html'.format(settings.HTML_ROOT), 0.5),
             ]
     def location(self, item):
         return item[0]


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:nijel:kolikdluzi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:nijel:kolikdluzi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)